### PR TITLE
Revert "Merge pull request #31 from publicmediaplatform/change-text-for-reset-password-new-account"

### DIFF
--- a/app/views/password_reset/new.haml
+++ b/app/views/password_reset/new.haml
@@ -12,8 +12,11 @@
         != flash.notice
     - else
       %span.help-block
-        %h2 Reset password
-        %p Please email support@pmp.io to have your password reset and emailed to you.
+        Instructions to reset your password will be emailed to the address associated with this username.
+    = render partial: 'sessions/hoster'
+    = negative_text_field_tag(@captcha, :username, class: 'form-control', autofocus: true, required: true, placeholder: 'Username')
+    %button.btn.btn-lg.btn-pmp.btn-block{type: 'submit'}
+      Email reset instructions
 
 -# nav links
 - content_for :logbox_links do

--- a/app/views/register/new.haml
+++ b/app/views/register/new.haml
@@ -12,8 +12,32 @@
         != flash.notice
     - else
       %span.help-block
-        %h2 New API user.
-        %p Please email support@pmp.io to have a new account created.
+        Request an API user for the PMP.
+    = render partial: 'sessions/hoster'
+    = negative_text_field_tag(@captcha, :name, class: 'form-control', autofocus: true, required: true, placeholder: 'Your name')
+    = negative_text_field_tag(@captcha, :email, class: 'form-control', required: true, placeholder: 'Contact email')
+    = negative_text_field_tag(@captcha, :organization, class: 'form-control', required: true, placeholder: 'Name of organization')
+    %select.form-control.cmspicker{name: 'cms[]', multiple: true, 'data-title' => 'What CMS do you use?'}
+      %option{value: 'Drupal'} Drupal
+      %option{value: 'Joomla!'} Joomla!
+      %option{value: 'NPR Core Publisher'} NPR Core Publisher
+      %option{value: 'PBS Bento'} PBS Bento
+      %option{value: 'Wordpress'} Wordpress
+      %option{'data-divider' => 'true'}
+      %option{value: 'Other', 'data-subtext' => 'Please explain below'} Other
+      %option{value: 'None'} None
+    = negative_text_area_tag(@captcha, :intention, class: 'form-control', required: true, placeholder: 'For what purpose do you intend to use the PMP?', rows: 6)
+    %button.btn.btn-lg.btn-pmp.btn-block{type: 'submit'}
+      Send request
+    .help-block.text-center
+      By using the PMP API you are agreeing <br/> to our
+      = link_to 'Terms of Use', terms_path
+
+-# doc links
+- content_for :logbox_docs do
+  .doc-link
+    = link_to service_path do
+      Service Level Agreement
 
 -# nav links
 - content_for :logbox_links do

--- a/spec/features/forgot_spec.rb
+++ b/spec/features/forgot_spec.rb
@@ -15,46 +15,46 @@ feature 'forgot password' do
     PasswordReset.create(email_address: 'foo@bar.com', user_name: pmp_username, user_guid: '12345678', host: pmp_host)
   end
 
-#  scenario 'fails to fill out all fields' do
-#    visit forgot_path
-#    click_button 'Email reset instructions'
-#    expect(page).to have_content('Please fill out all fields')
-#  end
+  scenario 'fails to fill out all fields' do
+    visit forgot_path
+    click_button 'Email reset instructions'
+    expect(page).to have_content('Please fill out all fields')
+  end
 
-#  scenario 'sets a fancy reverse captcha field' do
-#    visit forgot_path
-#    set_host_picker pmp_host
-#    fill_in 'Username', with: 'foobar'
-#    page.find('#username').set('foobar')
-#    click_button 'Email reset instructions'
-#    expect(page).to have_content('Hidden form fields were submitted')
-#  end
+  scenario 'sets a fancy reverse captcha field' do
+    visit forgot_path
+    set_host_picker pmp_host
+    fill_in 'Username', with: 'foobar'
+    page.find('#username').set('foobar')
+    click_button 'Email reset instructions'
+    expect(page).to have_content('Hidden form fields were submitted')
+  end
 
-#  scenario 'username not found', admin: true do
-#    visit forgot_path
-#    set_host_picker pmp_host
-#    fill_in 'Username', with: 'foobar93052758'
-#    click_button 'Email reset instructions'
-#    expect(page).to have_content('Unable to find a user by that name')
-#  end
+  scenario 'username not found', admin: true do
+    visit forgot_path
+    set_host_picker pmp_host
+    fill_in 'Username', with: 'foobar93052758'
+    click_button 'Email reset instructions'
+    expect(page).to have_content('Unable to find a user by that name')
+  end
 
-#  scenario 'too many users with that name' do
-#    allow_any_instance_of(PasswordResetController).to receive(:user_items) { [fake_user, fake_user] }
-#    visit forgot_path
-#    set_host_picker pmp_host
-#    fill_in 'Username', with: pmp_username
-#    click_button 'Email reset instructions'
-#    expect(page).to have_content('too many users with that name')
-#  end
+  scenario 'too many users with that name' do
+    allow_any_instance_of(PasswordResetController).to receive(:user_items) { [fake_user, fake_user] }
+    visit forgot_path
+    set_host_picker pmp_host
+    fill_in 'Username', with: pmp_username
+    click_button 'Email reset instructions'
+    expect(page).to have_content('too many users with that name')
+  end
 
-#  scenario 'user has no email' do
-#    allow_any_instance_of(PasswordResetController).to receive(:user_items) { [fake_user] }
-#    visit forgot_path
-#    set_host_picker pmp_host
-#    fill_in 'Username', with: pmp_username
-#    click_button 'Email reset instructions'
-#    expect(page).to have_content('No email associated with user')
-#  end
+  scenario 'user has no email' do
+    allow_any_instance_of(PasswordResetController).to receive(:user_items) { [fake_user] }
+    visit forgot_path
+    set_host_picker pmp_host
+    fill_in 'Username', with: pmp_username
+    click_button 'Email reset instructions'
+    expect(page).to have_content('No email associated with user')
+  end
 
   scenario 'invalid reset link' do
     expect { visit reset_password_path('foobar') }.to raise_error(ActiveRecord::RecordNotFound)
@@ -104,29 +104,29 @@ feature 'forgot password' do
     expect(PasswordReset.count).to eq(1)
   end
 
-#  scenario 'full reset path works', admin: true do
-#    visit forgot_path
-#    set_host_picker pmp_host
-#    fill_in 'Username', with: pmp_username
-#    click_button 'Email reset instructions'
-#    expect(page).to have_content('An email with reset instructions has been sent')
-#
-#    expect(PasswordReset.count).to eq(1)
-#    expect(PasswordReset.first.user_name).to eq(pmp_username)
-#
-#    expect(mails.count).to eq(1)
-#    expect(first_mail.from).to include('support@publicmediaplatform.org')
-#    expect(first_mail.subject).to eq("Reset your #{PasswordReset.first.host_title} password")
-#    expect(first_mail.body).to include(PasswordReset.first.token)
-#
-#    visit reset_password_path(PasswordReset.first.token)
-#    fill_in 'Username', with: pmp_username
-#    fill_in 'New password', with: pmp_password
-#    fill_in 'Confirm new password', with: pmp_password
-#    click_button 'Change password'
-#    expect(page).to have_content('Password changed!')
-#    expect(current_path).to eq(login_path)
-#    expect(PasswordReset.count).to eq(0)
-#  end
+  scenario 'full reset path works', admin: true do
+    visit forgot_path
+    set_host_picker pmp_host
+    fill_in 'Username', with: pmp_username
+    click_button 'Email reset instructions'
+    expect(page).to have_content('An email with reset instructions has been sent')
+
+    expect(PasswordReset.count).to eq(1)
+    expect(PasswordReset.first.user_name).to eq(pmp_username)
+
+    expect(mails.count).to eq(1)
+    expect(first_mail.from).to include('support@publicmediaplatform.org')
+    expect(first_mail.subject).to eq("Reset your #{PasswordReset.first.host_title} password")
+    expect(first_mail.body).to include(PasswordReset.first.token)
+
+    visit reset_password_path(PasswordReset.first.token)
+    fill_in 'Username', with: pmp_username
+    fill_in 'New password', with: pmp_password
+    fill_in 'Confirm new password', with: pmp_password
+    click_button 'Change password'
+    expect(page).to have_content('Password changed!')
+    expect(current_path).to eq(login_path)
+    expect(PasswordReset.count).to eq(0)
+  end
 
 end

--- a/spec/features/register_spec.rb
+++ b/spec/features/register_spec.rb
@@ -7,45 +7,45 @@ feature 'user registration' do
   let(:first_mail) { ActionMailer::Base.deliveries.first }
   before(:each)    { ActionMailer::Base.deliveries.clear }
 
-#  scenario 'fails to fill out all fields' do
-#    visit register_path
-#    click_button 'Send request'
-#    expect(page).to have_content('Please fill out all fields')
-#  end
+  scenario 'fails to fill out all fields' do
+    visit register_path
+    click_button 'Send request'
+    expect(page).to have_content('Please fill out all fields')
+  end
 
-#  scenario 'sets a fancy reverse captcha field' do
-#    visit register_path
-#    set_host_picker 'https://api.pmp.io'
-#    fill_in 'Your name', with: 'Foo Bar'
-#    fill_in 'Contact email', with: 'foo@bar.com'
-#    fill_in 'Name of organization', with: 'Foobar Inc'
-#    set_cms_picker ['Drupal', 'Wordpress']
-#    fill_in 'For what purpose do you intend to use the PMP?', with: 'Profit'
-#    page.find('#email').set('foobar')
-#    click_button 'Send request'
-#    expect(page).to have_content('Hidden form fields were submitted')
-#  end
+  scenario 'sets a fancy reverse captcha field' do
+    visit register_path
+    set_host_picker 'https://api.pmp.io'
+    fill_in 'Your name', with: 'Foo Bar'
+    fill_in 'Contact email', with: 'foo@bar.com'
+    fill_in 'Name of organization', with: 'Foobar Inc'
+    set_cms_picker ['Drupal', 'Wordpress']
+    fill_in 'For what purpose do you intend to use the PMP?', with: 'Profit'
+    page.find('#email').set('foobar')
+    click_button 'Send request'
+    expect(page).to have_content('Hidden form fields were submitted')
+  end
 
-#  scenario 'successful registration' do
-#    visit register_path
-#    set_host_picker 'https://api.pmp.io'
-#    fill_in 'Your name', with: 'Foo Bar'
-#    fill_in 'Contact email', with: 'foo@bar.com'
-#    fill_in 'Name of organization', with: 'Foobar Inc'
-#    set_cms_picker ['Drupal', 'Wordpress']
-#    fill_in 'For what purpose do you intend to use the PMP?', with: 'Profit'
-#    click_button 'Send request'
-#    expect(page).to have_content('your request has been sent')
-#    expect(current_path).to eq(login_path)
-#
-#    expect(mails.count).to eq(1)
-#    expect(first_mail.to).to include('support@publicmediaplatform.org')
-#    expect(first_mail.subject).to eq('PMP registration request from Foo Bar')
-#    expect(first_mail.body).to include('production')
-#    expect(first_mail.body).to include('foo@bar.com')
-#    expect(first_mail.body).to include('Foobar Inc')
-#    expect(first_mail.body).to include('Drupal, Wordpress')
-#    expect(first_mail.body).to include('Profit')
-#  end
+  scenario 'successful registration' do
+    visit register_path
+    set_host_picker 'https://api.pmp.io'
+    fill_in 'Your name', with: 'Foo Bar'
+    fill_in 'Contact email', with: 'foo@bar.com'
+    fill_in 'Name of organization', with: 'Foobar Inc'
+    set_cms_picker ['Drupal', 'Wordpress']
+    fill_in 'For what purpose do you intend to use the PMP?', with: 'Profit'
+    click_button 'Send request'
+    expect(page).to have_content('your request has been sent')
+    expect(current_path).to eq(login_path)
+
+    expect(mails.count).to eq(1)
+    expect(first_mail.to).to include('support@publicmediaplatform.org')
+    expect(first_mail.subject).to eq('PMP registration request from Foo Bar')
+    expect(first_mail.body).to include('production')
+    expect(first_mail.body).to include('foo@bar.com')
+    expect(first_mail.body).to include('Foobar Inc')
+    expect(first_mail.body).to include('Drupal, Wordpress')
+    expect(first_mail.body).to include('Profit')
+  end
 
 end


### PR DESCRIPTION
I reverted the PR that removed the password reset feature, and tested it locally.
And it worked.
Waiting permission to access the google doc file, to see more details about the original problem.