### PR TITLE
Fix false positives on negative_captcha

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
     multi_json (1.13.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
-    negative_captcha (0.3.3)
+    negative_captcha (0.5)
       actionpack
       activesupport
     netrc (0.11.0)

--- a/app/views/password_reset/new.haml
+++ b/app/views/password_reset/new.haml
@@ -14,7 +14,7 @@
       %span.help-block
         Instructions to reset your password will be emailed to the address associated with this username.
     = render partial: 'sessions/hoster'
-    = negative_text_field_tag(@captcha, :username, class: 'form-control', autofocus: true, required: true, placeholder: 'Username')
+    = negative_text_field_tag(@captcha, :username, class: 'form-control', autocomplete: 'invalid',autofocus: true, required: true, placeholder: 'Username')
     %button.btn.btn-lg.btn-pmp.btn-block{type: 'submit'}
       Email reset instructions
 

--- a/app/views/password_reset/show.haml
+++ b/app/views/password_reset/show.haml
@@ -19,8 +19,8 @@
       %select.hostpicker{name: :host, disabled: true}
         %option{value: @reset.host, selected: true}
           = @reset.host_title
-    = negative_text_field_tag(@captcha, :username, class: 'form-control', autofocus: true, required: true, placeholder: 'Username')
-    = negative_password_field_tag(@captcha, :password, class: 'form-control', autofocus: true, required: true, placeholder: 'New password')
-    = negative_password_field_tag(@captcha, :confirm_password, class: 'form-control', autofocus: true, required: true, placeholder: 'Confirm new password')
+    = negative_text_field_tag(@captcha, :username, class: 'form-control', autocomplete: 'invalid',autofocus: true, required: true, placeholder: 'Username')
+    = negative_password_field_tag(@captcha, :password, class: 'form-control', autocomplete: 'invalid',autofocus: true, required: true, placeholder: 'New password')
+    = negative_password_field_tag(@captcha, :confirm_password, class: 'form-control', autocomplete: 'invalid',autofocus: true, required: true, placeholder: 'Confirm new password')
     %button.btn.btn-lg.btn-pmp.btn-block{type: 'submit'}
       Change password

--- a/app/views/register/new.haml
+++ b/app/views/register/new.haml
@@ -14,9 +14,9 @@
       %span.help-block
         Request an API user for the PMP.
     = render partial: 'sessions/hoster'
-    = negative_text_field_tag(@captcha, :name, class: 'form-control', autofocus: true, required: true, placeholder: 'Your name')
-    = negative_text_field_tag(@captcha, :email, class: 'form-control', required: true, placeholder: 'Contact email')
-    = negative_text_field_tag(@captcha, :organization, class: 'form-control', required: true, placeholder: 'Name of organization')
+    = negative_text_field_tag(@captcha, :name, class: 'form-control', autocomplete: 'invalid', autofocus: true, required: true, placeholder: 'Your name')
+    = negative_text_field_tag(@captcha, :email, class: 'form-control', autocomplete: 'invalid', required: true, placeholder: 'Contact email')
+    = negative_text_field_tag(@captcha, :organization, class: 'form-control', autocomplete: 'invalid', required: true, placeholder: 'Name of organization')
     %select.form-control.cmspicker{name: 'cms[]', multiple: true, 'data-title' => 'What CMS do you use?'}
       %option{value: 'Drupal'} Drupal
       %option{value: 'Joomla!'} Joomla!
@@ -26,7 +26,7 @@
       %option{'data-divider' => 'true'}
       %option{value: 'Other', 'data-subtext' => 'Please explain below'} Other
       %option{value: 'None'} None
-    = negative_text_area_tag(@captcha, :intention, class: 'form-control', required: true, placeholder: 'For what purpose do you intend to use the PMP?', rows: 6)
+    = negative_text_area_tag(@captcha, :intention, class: 'form-control', autocomplete: 'invalid', required: true, placeholder: 'For what purpose do you intend to use the PMP?', rows: 6)
     %button.btn.btn-lg.btn-pmp.btn-block{type: 'submit'}
       Send request
     .help-block.text-center


### PR DESCRIPTION
 - the root of the problem was the browser autocomplete
 - add "autocomplete: 'invalid'", to disable autofill